### PR TITLE
added xml:lang-attribute to <text> in Īśvaravādimataparīkṣā

### DIFF
--- a/jitari-isvaravadimatapariksa.xml
+++ b/jitari-isvaravadimatapariksa.xml
@@ -163,8 +163,8 @@
     </revisionDesc>
 
   </teiHeader>
-<text>
-<body xml:lang="sa-Latn">
+<text xml:lang="sa-Latn">
+<body>
 <div><pb ed="gb" n="39"/>
 <head>*Īśvaravādimataparīkṣā</head><lb ed="gb"/>
 <note resp="#sarit-encoder-imp" xml:lang="de"><p><quote>Unter dem Titel <title>Anekāntavādanirāsa</title> hat <ref target="http://east.uni-hd.de/buddh/ind/26/75/570/">IYENGAR a.a.O.</ref>, 81-85 einen Text Jitāris ediert, der im Kolophon als <title>Digambaramataparīkṣā</title> bezeichnet wird. Er beginnt: <quote xml:lang="sa-Latn">idānīm ārhatamataṃ vicāryate; - ihāmī digambarāḥ dravyaparyāyarūpeṇa utpattisthitipralayātmakaṃ bhāvagrāmaṃ varṇayanti |...</quote> Im vorliegenden Konvolut findet sich nun ein Text, der eine ganz ähnliche Struktur hat, dessen Titel uns aber nicht erhalten ist. Er umfaßt die Folios IIB|9; IIA|9; IIB|6; IIA|6; IIB|11; IIA|11; IIB|10; IIA|10; IIB|12; IIA|12; (Schluß fehlt). Entsprechend der <title>Digambaramataparīkṣā</title> wird hier <title>Īśvaravādimataparīkṣā</title> als tentativer Titel vorgeschlagen.</quote> <ref target="#imp-buehnemann-1982">Bühnemann 1982</ref>, p. 19.</p></note>


### PR DESCRIPTION
If the the xml:lang="sa-Latn" is given to the <body> and <text> is left without attribute, the app lists the text as being in Devanagari.