### PR TITLE
correct dehāḥ to dehaḥ in Suśruta, sūtrasthana 21.3

### DIFF
--- a/susrutasamhita.xml
+++ b/susrutasamhita.xml
@@ -2733,7 +2733,7 @@
                         ta eva ca vyāpannāḥ pralayahetavaḥ / tadebhireva śoṇitacaturthaiḥ
                         saṃbhavasthitipralayeṣvapyavirahitaṃ śarīraṃ bhavati // </ab>
                     <ab xml:id="Su.1.21.4"><label>Su.1.21.4</label> bhavati cātra / </ab>
-                    <ab xml:id="Su.1.21.4ab"><label>Su.1.21.4ab</label> narte dehāḥ kaphādasti na
+                    <ab xml:id="Su.1.21.4ab"><label>Su.1.21.4ab</label> narte dehaḥ kaphādasti na
                         pittānna ca mārutāt / </ab>
                     <ab xml:id="Su.1.21.4cd"><label>Su.1.21.4cd</label> śoṇitādapi vā nityaṃ deha
                         etaistu dhāryate // </ab>


### PR DESCRIPTION
after reading Natalie Koehle's 2016 article in JAOS, page. 484, note 54.
The transcription of the printed edition was at fault here.